### PR TITLE
ci: add AI Review Bot and Gate workflows

### DIFF
--- a/.github/workflows/ai-review-bot.yml
+++ b/.github/workflows/ai-review-bot.yml
@@ -1,0 +1,17 @@
+name: AI Review Bot
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, review_requested]
+
+# Permissions ceiling for the reusable workflow's jobs
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  ai-review-bot:
+    # Centralized review logic from agent-plugins; uses main for stable tooling.
+    uses: unstoppabledomains/agent-plugins/.github/workflows/ai-review-bot-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -1,0 +1,26 @@
+name: AI Review Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+# Permissions ceiling for the reusable workflow's jobs
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  ai-review-gate:
+    # Centralized gate logic from agent-plugins.
+    uses: unstoppabledomains/agent-plugins/.github/workflows/ai-review-gate-reusable.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add AI Review Bot workflow (`ai-review-bot.yml`) — triggers AI code review on label or review request
- Add AI Review Gate workflow (`ai-review-gate.yml`) — enforces merge gate requiring AI or human approval

Both workflows call centralized reusable workflows from `agent-plugins` so they stay up to date automatically.

## Prerequisites
The following org-level secrets and variables must be configured for this repo:
- **Secrets**: `UD_PAT`, `ANTHROPIC_API_KEY` (and optionally `CODEX_API_KEY` for multi-agent reviews)
- **Variables**: `AI_REVIEW_BOT_USER`

## Test plan
- [ ] Verify workflows appear in the Actions tab after merge
- [ ] Open a test PR and confirm the AI Review Gate runs on PR open
- [ ] Add `ai-review-requested` label to a PR and confirm the AI Review Bot triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)